### PR TITLE
product cleanup 2

### DIFF
--- a/integration/clusternextgen_discover_test.go
+++ b/integration/clusternextgen_discover_test.go
@@ -45,6 +45,5 @@ func Test_NextGenDiscoverCommand(t *testing.T) {
 	if err := cmd.Run(ctx); err != nil {
 		t.Errorf("cluster command [%s] execution failed: %s", cmd.Key, err.Error())
 	}
-
 }
 

--- a/integration/clusternextgen_reset_test.go
+++ b/integration/clusternextgen_reset_test.go
@@ -44,6 +44,5 @@ func Test_NextGenResetCommand(t *testing.T) {
 
 	if err := cmd.Run(ctx); err != nil {
 		t.Errorf("cluster command [%s] execution failed: %s", cmd.Key, err.Error())
-	}
-
+	}	
 }

--- a/pkg/host/.#command.go
+++ b/pkg/host/.#command.go
@@ -1,1 +1,0 @@
-jnesbitt@freenovo.27757:1714631781

--- a/pkg/host/command.go
+++ b/pkg/host/command.go
@@ -17,13 +17,13 @@ var (
 //
 //	For all commands, we effectively do discovery for the hosts
 func (hc *HostsComponent) CommandBuild(ctx context.Context, cmd *action.Command) error {
-	p := stepped.NewSteppedPhase(CommandKeyDiscover, dependency.Requirements{}, hc.deps, []string{dependency.EventKeyActivated})
-
-	p.Steps().Add(&discoverStep{
-		id: hc.id,
-	})
-
-	cmd.Phases.Add(p)
+	if len(hc.deps) > 0 { // only discover if something else needs us
+		p := stepped.NewSteppedPhase(CommandKeyDiscover, dependency.Requirements{}, hc.deps, []string{dependency.EventKeyActivated})
+		p.Steps().Add(&discoverStep{
+			id: hc.id,
+		})
+		cmd.Phases.Add(p)
+	}
 
 	return nil
 }

--- a/pkg/product/k0s/command.go
+++ b/pkg/product/k0s/command.go
@@ -59,13 +59,16 @@ func (c K0S) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		cmd.Phases.Add(p)
 
 	case action.CommandKeyReset:
-		pd := stepped.NewSteppedPhase(CommandPhaseApply, rs, ds, []string{dependency.EventKeyActivated})
-		pd.Steps().Add(
-			&discoverStep{
-				id: c.Name(),
-			},
-		)
-		cmd.Phases.Add(pd)
+		if len(ds) > 0 { // only discover if something else needs us
+
+			pd := stepped.NewSteppedPhase(CommandPhaseApply, rs, ds, []string{dependency.EventKeyActivated})
+			pd.Steps().Add(
+				&discoverStep{
+					id: c.Name(),
+				},
+			)
+			cmd.Phases.Add(pd)
+		}
 
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{

--- a/pkg/product/mcr/command.go
+++ b/pkg/product/mcr/command.go
@@ -53,13 +53,16 @@ func (c MCR) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		cmd.Phases.Add(p)
 
 	case action.CommandKeyReset:
-		pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
-		pd.Steps().Add(
-			&discoverStep{
-				id: c.Name(),
-			},
-		)
-		cmd.Phases.Add(pd)
+		if len(ds) > 0 { // only discover if something else needs us
+
+			pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
+			pd.Steps().Add(
+				&discoverStep{
+					id: c.Name(),
+				},
+			)
+			cmd.Phases.Add(pd)
+		}
 
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{

--- a/pkg/product/mke3/command.go
+++ b/pkg/product/mke3/command.go
@@ -49,13 +49,15 @@ func (c MKE3) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		cmd.Phases.Add(p)
 
 	case action.CommandKeyReset:
-		pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
-		pd.Steps().Add(
-			&discoverStep{
-				id: c.Name(),
-			},
-		)
-		cmd.Phases.Add(pd)
+		if len(ds) > 0 { // only discover if something else needs us
+			pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
+			pd.Steps().Add(
+				&discoverStep{
+					id: c.Name(),
+				},
+			)
+			cmd.Phases.Add(pd)
+		}
 
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{

--- a/pkg/product/mke4/command.go
+++ b/pkg/product/mke4/command.go
@@ -46,13 +46,15 @@ func (c MKE4) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		cmd.Phases.Add(p)
 
 	case action.CommandKeyReset:
-		pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
-		pd.Steps().Add(
-			&discoverStep{
-				id: c.Name(),
-			},
-		)
-		cmd.Phases.Add(pd)
+		if len(ds) > 0 { // only discover if something else needs us
+			pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
+			pd.Steps().Add(
+				&discoverStep{
+					id: c.Name(),
+				},
+			)
+			cmd.Phases.Add(pd)
+		}
 
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{

--- a/pkg/product/msr4/command.go
+++ b/pkg/product/msr4/command.go
@@ -49,13 +49,15 @@ func (c MSR4) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		cmd.Phases.Add(p)
 
 	case action.CommandKeyReset:
-		pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
-		pd.Steps().Add(
-			&discoverStep{
-				id: c.Name(),
-			},
-		)
-		cmd.Phases.Add(pd)
+		if len(ds) > 0 { // only discover if something else needs us
+			pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
+			pd.Steps().Add(
+				&discoverStep{
+					id: c.Name(),
+				},
+			)
+			cmd.Phases.Add(pd)
+		}
 
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{


### PR DESCRIPTION
- on reset, products only discover before resetting if they provide any dependencies