### PR TITLE
MKE uninstall action

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,22 +1,43 @@
 # TODO
 
+## Logging
+
+- [ ] (log-sanitize) Sanitize output to prevent logging of sensitive information. Probably components should be able to add sensitive values to a list as they run
+
 ## Action 
 
 - [X] (phase-overwrite-warn) Phase accessors should probably warn when an existing phase is dropped because a new one with the same name is added.
 - [ ] (phase-order-debug) The Phase sort graph library only returns a boolean on failure which means we cannot give the user details about any failure (look for a new library?)
+- [ ] (allow-dep-match-fail) Allow dependency matching to fail, to allow separation of actions for things like the cli. This places the responsibility of Dependency matching on the user
 
 ## Dependency 
 
 - [ ] (unique-event-ids) Events and Event keys need to be unique, but the code is very reled about enforcing that. We should probably make the Unique part immutable and unique.
 
+## Cluster 
+
+- [ ] (rename) Rename to "project"
+- [ ] (allow-dep-match-fail) Allow dependency matching to fail, to allow separation of actions for things like the cli. This places the responsibility of Dependency matching on the user
+
 ## Host 
 
 - [x] (host-network-discover) Hosts need to be able to discover their networking (internal) so that we can activate swarm using the advertise address
+- [ ] (flexible-host) Allow Hosts to have component specific configuration/functionalily so that we can configure host specific things like docker-sudo, mcr-daemon-config. Maybe a plugin system, or allow multiple handlers per host?
+- [ ] (host-hooks) Allow host hooks. Perhaps rely on action.Events or action.Phases as markers.
 
 ## Component
 
-- [ ] develop a better state strategy with locking
+- [ ] (component-state) develop a better state strategy/pattern for components. Requirements would include: locking, debug/output, config comparison, io/storage?
 
-## Docker Host 
+## Docker:DockerExec
 
-- [ ] we call docker info and swarm inspect repeatedly for leaders. This host should likely cache this information.
+- [ ] (dockerexec-cache) we call docker info and swarm inspect repeatedly for leaders. This host should likely cache this information. The whole dockerexec client could use a caching mechanism.
+- [ ] (docker-exec-injection) confirm that we are not allowing shell injection with user data being used in docker commands
+
+## Products 
+
+- [ ] (product-discover-strategy) develop a strategy for the Discover operations that is more clear about state, and allows for expecting to fail (like checking that a product is uninstalled after running uninstall.
+
+## Product:MKE3
+
+- [X] (mke3-config-separate) separate install and upgrade config so that it is obvious to the user what values are supported for each operation.

--- a/examples/terraform/aws/launchpad.tf
+++ b/examples/terraform/aws/launchpad.tf
@@ -169,15 +169,17 @@ spec:
     mke3:
       version: ${var.launchpad.mke_version}
       imageRepo: docker.io/mirantis
-      adminUsername: "${var.launchpad.mke_connect.username}
-      adminPassword: "${var.launchpad.mke_connect.password}"
-      san: "${local.MKE_URL}"
-      installFlags: 
-      - "--default-node-orchestrator=kubernetes"
-      - "--nodeport-range=32768-35535"
-      upgradeFlags:
-      - "--force-recent-backup"
-      - "--force-minimums"
+      install:
+        adminUsername: "${var.launchpad.mke_connect.username}"
+        adminPassword: "${var.launchpad.mke_connect.password}"
+        san: "${local.MKE_URL}"
+        flags: 
+        - "--default-node-orchestrator=kubernetes"
+        - "--nodeport-range=32768-35535"
+      upgrade:
+        flags:
+        - "--force-recent-backup"
+        - "--force-minimums"
       prune: true
 %{if local.has_msr}
     msr2:

--- a/pkg/dependency/dependency_test.go
+++ b/pkg/dependency/dependency_test.go
@@ -87,7 +87,7 @@ func Test_MatchRequirements_ShouldFail(t *testing.T) {
 
 func Test_MatchRequirements_Empty(t *testing.T) {
 	ctx := context.Background()
-	r := mock.Requirement("mock", "", nil)              // only needed as an argument. fds do all of the work
+	r := mock.Requirement("mock", "", nil)     // only needed as an argument. fds do all of the work
 	fds := []dependency.ProvidesDependencies{} // empty list of handlers/fullfillers
 
 	_, err := dependency.MatchRequirementDependency(ctx, r, fds)

--- a/pkg/product/mcr/action_discover.go
+++ b/pkg/product/mcr/action_discover.go
@@ -40,7 +40,7 @@ func (s *discoverStep) Run(ctx context.Context) error {
 		if s.failOnError {
 			return fmt.Errorf("docker info update failed: %s", err.Error())
 		}
-		slog.WarnContext(ctx, "At least one host was missing MCR installation")
+		slog.InfoContext(ctx, fmt.Sprintf("At least one host was missing MCR installation: %s", err.Error()))
 	}
 
 	slog.InfoContext(ctx, "MCR discovery succeeded")

--- a/pkg/product/mke3/action_discover.go
+++ b/pkg/product/mke3/action_discover.go
@@ -7,6 +7,7 @@ import (
 )
 
 type discoverStep struct {
+	baseStep
 	id string
 }
 

--- a/pkg/product/mke3/action_downloadclientbundle.go
+++ b/pkg/product/mke3/action_downloadclientbundle.go
@@ -7,6 +7,7 @@ import (
 )
 
 type downloadClientBundleStep struct {
+	baseStep
 	id string
 }
 

--- a/pkg/product/mke3/action_preparenodes.go
+++ b/pkg/product/mke3/action_preparenodes.go
@@ -7,6 +7,7 @@ import (
 )
 
 type prepareNodesStep struct {
+	baseStep
 	id string
 }
 

--- a/pkg/product/mke3/command.go
+++ b/pkg/product/mke3/command.go
@@ -32,7 +32,8 @@ func (c *MKE3) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		p := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
 		p.Steps().Add(
 			&discoverStep{
-				id: c.Name(),
+				baseStep: bs,
+				id:       c.Name(),
 			},
 		)
 		cmd.Phases.Add(p)
@@ -41,7 +42,8 @@ func (c *MKE3) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		p := stepped.NewSteppedPhase(CommandPhaseApply, rs, ds, []string{dependency.EventKeyActivated})
 		p.Steps().Merge(stepped.Steps{
 			&discoverStep{
-				id: c.Name(),
+				baseStep: bs,
+				id:       c.Name(),
 			},
 			&prepareNodesStep{
 				id: c.Name(),
@@ -71,7 +73,8 @@ func (c *MKE3) CommandBuild(ctx context.Context, cmd *action.Command) error {
 			pd := stepped.NewSteppedPhase(CommandPhaseDiscover, rs, ds, []string{dependency.EventKeyActivated})
 			pd.Steps().Add(
 				&discoverStep{
-					id: c.Name(),
+					baseStep: bs,
+					id:       c.Name(),
 				},
 			)
 			cmd.Phases.Add(pd)
@@ -80,7 +83,8 @@ func (c *MKE3) CommandBuild(ctx context.Context, cmd *action.Command) error {
 		pr := stepped.NewSteppedPhase(CommandPhaseReset, rs, ds, []string{dependency.EventKeyDeActivated})
 		pr.Steps().Merge(stepped.Steps{
 			&uninstallMKEStep{
-				id: c.Name(),
+				baseStep: bs,
+				id:       c.Name(),
 			},
 		})
 		cmd.Phases.Add(pr)


### PR DESCRIPTION
- MKE uninstall action now uninstalls.
- MKE install / upgrade options now separated to keep things clear about where they can be used.

Also:
- dropped DockerExec info cache, which was not designed wholisitically
- fix broken tf for launchpad yaml output
- more TODO added