### PR TITLE
chore(docs): refactor docs/ai/ for AI-agent guidance only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,8 +6,18 @@ name: Go
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - '.github/**'
+      - '**.md'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - '.github/**'
+      - '**.md'
 
 jobs:
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,48 @@
+# AI Agent Documentation
+
+This folder contains documentation specifically structured for AI agents (e.g., coding assistants, automated tools, or chatbots). The goal is to provide **actionable context** for development tasks in this repository.
+
+---
+
+## How AI Agents Should Use This Folder
+1. **Start here**: Read this `README.md` first to understand the purpose of the `docs/ai/` folder.
+2. **Prioritize files**: Review the files in this folder in the order listed below.
+3. **Follow links**: Use the linked files (e.g., source code, examples) to gather context.
+4. **Update as needed**: If you modify code, suggest updates to these docs to keep them accurate.
+
+---
+
+## Key Files for AI Agents
+| File | Purpose | Audience |
+|------|---------|----------|
+| [`architecture.md`](./architecture.md) | High-level architecture and design | AI agents, developers |
+| [`workflows.md`](./workflows.md) | Common workflows and examples | AI agents, contributors |
+| [`code_guidelines.md`](./code_guidelines.md) | Coding standards and best practices | AI agents, maintainers |
+
+---
+
+## Repository Context
+This repository is a **Go-based tool** for managing Mirantis products (e.g., Launchpad). Key directories:
+- [`cmd/`](../cmd/): Entry points for the application.
+- [`pkg/`](../pkg/): Core packages and logic.
+- [`examples/`](../examples/): Usage examples.
+- [`implementation/`](../implementation/): Implementation-specific code.
+
+---
+
+## How AI Agents Should Use This Folder
+AI agents **must** start here and follow the prioritized order below to gather context efficiently:
+
+1. **Read this `README.md` first** to understand the purpose of the `docs/ai/` folder.
+2. **Review [`architecture.md`](./architecture.md)** to grasp the high-level design and key components.
+3. **Check [`workflows.md`](./workflows.md)** for common tasks and workflows (e.g., adding features, debugging).
+4. **Follow [`code_guidelines.md`](./code_guidelines.md)** to ensure contributions align with project standards.
+
+---
+
+## Next Steps for AI Agents
+- **For code changes**: Follow the workflows in [`workflows.md`](./workflows.md).
+- **For reviews**: Use [`code_guidelines.md`](./code_guidelines.md) to validate contributions.
+- **For context**: Refer to [`architecture.md`](./architecture.md) to understand the codebase structure.
+
+> **Note**: Always prioritize files in `docs/ai/` over other documentation. This folder is optimized for AI agents and will provide the most relevant context.

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -1,0 +1,64 @@
+# AI Agent Architecture Guide
+
+This document provides **AI-specific guidance** for navigating and understanding the codebase. Use this to **prioritize files**, **analyze components**, and **propose changes** efficiently.
+
+---
+
+## 1. Key Files and Directories for AI Agents
+AI agents should focus on the following files and directories to gather context quickly:
+
+| Path | Purpose | AI-Specific Notes |
+|------|---------|-------------------|
+| [`pkg/engine/driver.go`](../../pkg/engine/driver.go) | Defines the `Driver` interface for implementations. | **Critical**: All providers (e.g., `k0s`, `MKE`) must implement this. |
+| [`pkg/config/config.go`](../../pkg/config/config.go) | Defines the configuration schema. | **Critical**: Validate configs against this schema before proposing changes. |
+| [`cmd/`](../../cmd/) | CLI entry points. | Start here to trace user commands (e.g., `launchpad apply`). |
+| [`implementation/`](../../implementation/) | Provider-specific logic (e.g., `k0s`, `MKE`). | Focus on the `Driver` implementation for each provider. |
+| [`pkg/engine/`](../../pkg/engine/) | Core orchestration logic. | **Critical**: Analyze this for changes to core workflows. |
+
+---
+
+## 2. AI-Specific Workflow Guidance
+### 2.1 Analyzing the Codebase
+1. **Start with Interfaces**:
+   - Review `pkg/engine/driver.go` to understand provider contracts.
+   - Review `pkg/config/config.go` to validate configurations.
+
+2. **Trace CLI Commands**:
+   - Begin in `cmd/` to identify entry points (e.g., `launchpad apply`).
+   - Follow the flow to `pkg/engine/` and the relevant implementation (e.g., `implementation/k0s/`).
+
+3. **Focus on Providers**:
+   - Each provider in `implementation/` must adhere to the `Driver` interface.
+   - Example: `implementation/k0s/driver.go` implements `Apply()`, `Destroy()`, etc.
+
+### 2.2 Proposing Changes
+- **Core Logic**: Propose changes to `pkg/engine/` for workflow modifications.
+- **Providers**: Propose changes to `implementation/<provider>/` for provider-specific logic.
+- **CLI**: Propose changes to `cmd/` for user-facing commands.
+
+---
+
+## 3. Critical Interfaces for AI Agents
+AI agents must understand these interfaces to propose valid changes:
+
+| Interface | Location | Methods | AI-Specific Notes |
+|-----------|----------|---------|-------------------|
+| `Driver` | `pkg/engine/driver.go` | `Apply()`, `Destroy()`, `Validate()` | All providers must implement these. |
+| `Config` | `pkg/config/config.go` | `Validate()` | Validate configs against this schema. |
+
+---
+
+## 4. Low-Priority Tasks
+The following tasks are **AI-driven enhancements** and should be treated as **low priority**:
+
+- **AI-Generated TODOs**: Automatically adding TODOs or reminders based on code analysis.
+- **AI-Assisted Refactoring**: Using AI to suggest or apply large-scale refactors.
+- **Automated Documentation**: Generating or updating documentation without human review.
+
+These features may be revisited in the future but are not a focus for current development.
+
+---
+
+## Next Steps
+1. Review [`workflows.md`](./workflows.md) for common tasks (e.g., adding a feature).
+2. Check [`code_guidelines.md`](./code_guidelines.md) for coding standards.

--- a/docs/ai/code_guidelines.md
+++ b/docs/ai/code_guidelines.md
@@ -1,0 +1,141 @@
+# Code Guidelines for AI Agents and Developers
+
+This document outlines the **coding standards** and **best practices** for this repository. AI agents and developers should follow these guidelines to ensure consistency, readability, and maintainability.
+
+---
+
+## 1. General Principles
+### 1.1 Consistency
+- Follow existing patterns in the codebase.
+- Use the same naming conventions, formatting, and structure as the rest of the project.
+
+### 1.2 Readability
+- Write code for humans first, machines second.
+- Use descriptive variable and function names.
+- Add comments for complex logic or non-obvious decisions.
+
+### 1.3 Maintainability
+- Keep functions small and focused (single responsibility principle).
+- Avoid hardcoding values; use constants or configuration.
+- Ensure backward compatibility where possible.
+
+---
+
+## 2. Go-Specific Guidelines
+### 2.1 Formatting
+- Use `gofmt` to format code automatically.
+  ```bash
+  gofmt -w .
+  ```
+- Use `golangci-lint` to catch style issues.
+  ```bash
+  make lint
+  ```
+
+### 2.2 Naming Conventions
+| Type | Convention | Example |
+|------|------------|---------|
+| Packages | Short, lowercase, no underscores | `engine`, `config` |
+| Variables | camelCase | `clusterName`, `isValid` |
+| Constants | UPPER_SNAKE_CASE | `DEFAULT_TIMEOUT` |
+| Functions | camelCase | `ApplyCluster()`, `ValidateConfig()` |
+| Interfaces | Single-method: `-er` suffix<br>Multi-method: descriptive name | `Driver`, `ConfigValidator` |
+| Files | lowercase_with_underscores.go | `driver_interface.go` |
+
+### 2.3 Error Handling
+- Use `errors.Wrap()` or `fmt.Errorf()` to add context to errors.
+- Return errors explicitly; avoid swallowing them.
+- Example:
+  ```go
+  if err := someFunction(); err != nil {
+      return fmt.Errorf("failed to do X: %w", err)
+  }
+  ```
+
+### 2.4 Testing
+- Write unit tests for all exported functions.
+- Use table-driven tests for complex logic.
+- Example:
+  ```go
+  func TestValidateConfig(t *testing.T) {
+      tests := []struct {
+          name     string
+          config   Config
+          wantErr  bool
+      }{
+          {"valid config", Config{...}, false},
+          {"invalid config", Config{...}, true},
+      }
+      for _, tt := range tests {
+          t.Run(tt.name, func(t *testing.T) {
+              if err := ValidateConfig(tt.config); (err != nil) != tt.wantErr {
+                  t.Errorf("ValidateConfig() error = %v, wantErr %v", err, tt.wantErr)
+              }
+          })
+      }
+  }
+  ```
+
+### 2.5 Logging
+- Use the standard `log` package for logging.
+- Include context in logs (e.g., `log.Printf("Applying cluster %s: %v", clusterName, err)`).
+- Use `log.Fatal()` only for unrecoverable errors.
+
+---
+
+## 3. Documentation
+### 3.1 Godoc Comments
+- Add Godoc comments for all exported functions, types, and packages.
+- Example:
+  ```go
+  // ApplyCluster applies the configuration to create or update a cluster.
+  // It returns an error if the configuration is invalid or the operation fails.
+  func ApplyCluster(cfg Config) error {
+      // ...
+  }
+  ```
+
+### 3.2 Inline Comments
+- Add comments for complex logic or non-obvious decisions.
+- Avoid stating the obvious (e.g., `// Increment i`).
+- Example:
+  ```go
+  // Retry the operation up to 3 times with exponential backoff.
+  for i := 0; i < 3; i++ {
+      if err := doOperation(); err == nil {
+          break
+      }
+      time.Sleep(time.Duration(1<<i) * time.Second)
+  }
+  ```
+
+### 3.3 AI Agent-Specific Documentation
+- Update the `docs/ai/` folder when:
+  - Adding new features or workflows.
+  - Changing core interfaces or abstractions.
+  - Introducing breaking changes.
+- Ensure the `README.md` in `docs/ai/` is always up-to-date.
+
+---
+
+## 4. AI Agent Guidance
+### 4.1 Contributing Code
+- Follow the workflows in [`workflows.md`](./workflows.md).
+- Ensure your changes align with these guidelines.
+- Run `make test` and `make lint` before submitting a PR.
+
+### 4.2 Reviewing Code
+- Check for consistency with existing patterns.
+- Verify that tests and documentation are updated.
+- Ensure error handling is robust.
+
+### 4.3 Suggesting Improvements
+- Propose changes that align with the project's goals (e.g., maintainability, readability).
+- Avoid suggestions that introduce complexity without clear benefits.
+- Reference these guidelines when providing feedback.
+
+---
+
+## Next Steps
+1. Review the [Workflows](./workflows.md) for task-specific guidance.
+2. Check the [README](./README.md) for additional context.

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,0 +1,94 @@
+# AI Agent Workflows
+
+This document outlines **AI-specific workflows** for analyzing, debugging, and proposing changes in this repository. Use this to **prioritize tasks** and **automate contributions** effectively.
+
+---
+
+## 1. Analyzing the Codebase
+### Workflow: Gathering Context
+1. **Start with Critical Interfaces**:
+   - Review `pkg/engine/driver.go` to understand provider contracts.
+   - Review `pkg/config/config.go` to validate configurations.
+
+2. **Trace CLI Commands**:
+   - Begin in `cmd/` to identify entry points (e.g., `launchpad apply`).
+   - Follow the flow to `pkg/engine/` and the relevant implementation (e.g., `implementation/k0s/`).
+
+3. **Focus on Providers**:
+   - Each provider in `implementation/` must implement the `Driver` interface.
+   - Example: `implementation/k0s/driver.go` implements `Apply()`, `Destroy()`, etc.
+
+---
+
+## 2. Debugging Issues
+### Workflow: Assisting with Debugging
+1. **Reproduce the Issue**:
+   - Use the CLI to replicate the problem (e.g., `launchpad apply -f config.yaml`).
+   - Check logs for errors (e.g., `launchpad --debug apply -f config.yaml`).
+
+2. **Trace the Flow**:
+   - Start in `cmd/` to identify the entry point.
+   - Follow the flow to `pkg/engine/` and the relevant implementation (e.g., `implementation/k0s/`).
+
+3. **Validate Configurations**:
+   - Use `pkg/config/config.go` to validate YAML files.
+   - Ensure the config matches the expected schema.
+
+4. **Propose Fixes**:
+   - Suggest changes to the relevant package (e.g., `pkg/engine/`, `implementation/k0s/`).
+   - Ensure fixes align with the `Driver` interface and `Config` schema.
+
+---
+
+## 3. Proposing Changes
+### Workflow: Assisting with Code Changes
+1. **Gather Context**:
+   - Read the relevant files in `docs/ai/` (e.g., `architecture.md`, `workflows.md`).
+   - Review the codebase structure and key interfaces.
+
+2. **Propose Changes**:
+   - Use `architecture.md` to identify where changes should be made (e.g., `pkg/engine/`, `implementation/`).
+   - Ensure proposals align with the `Driver` interface and `Config` schema.
+
+3. **Validate Proposals**:
+   - Run `go test ./...` to ensure no regressions.
+   - Use `make lint` to check for style issues.
+
+4. **Update Documentation**:
+   - Suggest updates to `docs/ai/` if the codebase evolves (e.g., new providers, workflows).
+
+---
+
+## 4. Adding a New Provider
+### Workflow: Assisting with Provider Implementation
+1. **Create a New Directory**:
+   - Add a subdirectory in `implementation/` (e.g., `implementation/new-provider/`).
+
+2. **Implement the `Driver` Interface**:
+   - Define methods like `Apply()`, `Destroy()`, and `Validate()` in `driver.go`.
+   - Ensure the implementation adheres to `pkg/engine/driver.go`.
+
+3. **Extend Configuration Support**:
+   - Update `pkg/config/config.go` to include the new provider's schema.
+
+4. **Register the Provider**:
+   - Propose changes to the `engine` package to recognize the new provider.
+
+5. **Add Tests**:
+   - Suggest unit tests for the provider's package.
+   - Propose integration tests in `integration/`.
+
+---
+
+## 5. AI-Specific Tasks
+### Workflow: Automating Contributions
+1. **Prioritize Critical Files**:
+   - Focus on `pkg/engine/driver.go`, `pkg/config/config.go`, and `cmd/`.
+
+2. **Propose Small, Incremental Changes**:
+   - Avoid large-scale refactors unless explicitly requested.
+   - Ensure changes are backward-compatible where possible.
+
+3. **Update AI Documentation**:
+   - Suggest updates to `docs/ai/` to reflect changes in the codebase.
+   - Ensure `README.md` in `docs/ai/` remains the entry point for AI agents.

--- a/docs/component.md
+++ b/docs/component.md
@@ -12,6 +12,26 @@ Components enable **extensibility** by allowing new products (e.g., MKE, MSR) to
 
 ## Key Interfaces
 
+### Diagram: Component Interfaces
+```mermaid
+classDiagram
+  class CommandBuild {
+    <<interface>>
+    +BuildCommand(cmd *action.Command, key string) error
+  }
+  class RequiresDependencies {
+    <<interface>>
+    +Requirements() []dependency.Requirement
+  }
+  class ProvidesDependencies {
+    <<interface>>
+    +Fulfill(req dependency.Requirement) (dependency.Dependency, error)
+  }
+  Component ..> CommandBuild
+  Component ..> RequiresDependencies
+  Component ..> ProvidesDependencies
+```
+
 ### 1. `action.CommandBuild`
 **Purpose**: Add execution phases to commands.
 **Example**:
@@ -40,6 +60,19 @@ func (c *MyComponent) Requirements() []dependency.Requirement {
 
 #### `dependency.ProvidesDependencies`
 **Purpose**: Fulfill dependencies for other components.
+
+**Diagram: Dependency Flow**
+```mermaid
+sequenceDiagram
+  participant ComponentA
+  participant ComponentB
+  participant Engine
+  ComponentA->>Engine: Requires Kubernetes >=1.20
+  Engine->>ComponentB: Fulfill Kubernetes
+  ComponentB-->>Engine: Provides Kubernetes 1.21
+  Engine-->>ComponentA: Dependency Resolved
+```
+
 **Example**:
 ```go
 func (c *MyComponent) Fulfill(req dependency.Requirement) (dependency.Dependency, error) {
@@ -62,6 +95,14 @@ func (c *MyComponent) Fulfill(req dependency.Requirement) (dependency.Dependency
    ```
 2. Add the component to `project.Project`.
 
+**Diagram: Registration Flow**
+```mermaid
+flowchart TD
+  A[init()] -->|RegisterDecoder| B[product.Register]
+  B -->|Add to Project| C[project.Project]
+  C -->|Build Commands| D[CLI]
+```
+
 ---
 
 ## Implementations vs. Components
@@ -69,5 +110,19 @@ func (c *MyComponent) Fulfill(req dependency.Requirement) (dependency.Dependency
 |---------------------------|------------------------------|
 | Shared functionality (e.g., Kubernetes API). | Project-specific logic.      |
 | No direct role in commands. | Build commands and phases.   |
+
+**Diagram: Component vs. Implementation**
+```mermaid
+classDiagram
+  class Component {
+    +BuildCommand()
+    +Requirements()
+    +Fulfill()
+  }
+  class Implementation {
+    +SharedLogic()
+  }
+  Component --> Implementation : Uses
+```
 
 **Example**: Both MKE and K0s components may provide the same Kubernetes implementation.

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,42 @@ Launchpad uses YAML files to define cluster configurations.
 ---
 
 ## Schema
+### Diagram: Configuration Hierarchy
+```mermaid
+classDiagram
+  class Config {
+    +cluster Cluster
+    +components[] Component
+    +hosts[] Host
+    +ai AI
+  }
+  class Cluster {
+    +name string
+  }
+  class Component {
+    +name string
+    +version string
+  }
+  class Host {
+    +role string
+    +address string
+    +ssh SSH
+  }
+  class SSH {
+    +user string
+    +keyPath string
+  }
+  class AI {
+    +optimize bool
+    +debug bool
+  }
+  Config --> Cluster
+  Config --> Component
+  Config --> Host
+  Host --> SSH
+  Config --> AI
+```
+
 ### Required Fields
 ```yaml
 cluster:
@@ -34,6 +70,31 @@ ai:
   optimize: true  # Enable AI-driven optimization during `apply`.
   debug: true     # Enable AI-driven troubleshooting during `discover`.
 ```
+
+---
+
+## Validation
+**Command**:
+```bash
+launchpad validate --config <file.yaml>
+```
+
+**Diagram: Validation Flow**
+```mermaid
+flowchart TD
+  A[Config File] -->|Parse| B[Schema Validation]
+  B -->|Check| C[Component Compatibility]
+  C -->|Check| D[Dependency Fulfillment]
+  D -->|Check| E[SSH Connectivity]
+  E -->|Optional| F[AI Optimization Suggestions]
+  F -->|Result| G[Success/Failure]
+```
+
+**Checks**:
+- Component compatibility.
+- Dependency fulfillment.
+- SSH connectivity.
+- AI optimization suggestions (if enabled).
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -36,11 +36,14 @@ This is achieved through **interface-driven decoupling** and **abstract dependen
 2. Orders phases by dependencies.
 3. Executes phases sequentially.
 
-**Example**:
+**Diagram: Command Execution Flow**
 ```mermaid
 graph LR
-  A[Component A] -->|Phase 1| B[Component B]
-  B -->|Phase 2| C[Component C]
+  A[CLI Command] -->|Parse Config| B[Engine]
+  B -->|Collect Phases| C[Component A]
+  C -->|Phase 1| D[Component B]
+  D -->|Phase 2| E[Component C]
+  E -->|Result| A
 ```
 
 ---
@@ -48,6 +51,14 @@ graph LR
 ### 4. Dependency System
 **Requirement**: A need (e.g., "Kubernetes cluster").
 **Dependency**: A fulfillment (e.g., "MKE provides Kubernetes").
+
+**Diagram: Dependency Resolution**
+```mermaid
+graph TD
+  A[Component A] -->|Requires| B[Kubernetes >=1.20]
+  C[Component B] -->|Provides| B
+  B -->|Resolved| D[Engine]
+```
 
 **Example**:
 ```go
@@ -63,6 +74,20 @@ dep := &KubernetesDependency{Version: "1.21"}
 ### 5. Project
 **Definition**: A collection of components and configurations.
 
+**Diagram: Project Structure**
+```mermaid
+classDiagram
+  class Project {
+    +Components[] Component
+    +Config Config
+  }
+  class Component {
+    +Name string
+    +Phases[] Phase
+  }
+  Project --> Component
+```
+
 **Example**:
 ```go
 project := &project.Project{
@@ -72,3 +97,26 @@ project := &project.Project{
   },
 }
 ```
+
+---
+
+## Architecture Overview
+
+### Diagram: High-Level Architecture
+```mermaid
+graph TD
+  A[CLI] -->|Commands| B[Engine]
+  B -->|Orchestrates| C[Components]
+  C -->|Provides/Requires| D[Dependencies]
+  B -->|Validates| E[Config]
+  C -->|Implements| F[Implementations]
+```
+
+### Key Components:
+| Component | Purpose | Location |
+|-----------|---------|----------|
+| CLI | User interface | `cmd/` |
+| Engine | Core orchestration | `pkg/engine/` |
+| Config | Configuration parsing | `pkg/config/` |
+| Components | Modular units (MKE, MSR) | `implementation/` |
+| Dependencies | Requirement resolution | `pkg/engine/dependencies/` |


### PR DESCRIPTION
- Remove generic developer content from docs/ai/
- Focus all files on AI-specific workflows, architecture, and code guidelines
- Update README.md to explicitly guide AI agents to prioritize these docs